### PR TITLE
ci: add the directory "util" to be part of github workflow

### DIFF
--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -16,4 +16,5 @@ jobs:
       uses: jidicula/clang-format-action@v3.4.0
       with:
         clang-format-version: '11'
-        check-path: 'fs'
+        check-path-fs: 'fs'
+        check-path-util: 'util'


### PR DESCRIPTION
This can catch any lint warnings/errors in util/zenfs.cc

Signed-off-by: Aravind Ramesh <aravind.ramesh@wdc.com>